### PR TITLE
Renamed platform module to prevent stdlib name collisions and fixed o…

### DIFF
--- a/goenv/__init__.py
+++ b/goenv/__init__.py
@@ -27,7 +27,7 @@ import sys
 from constants import XDG_CACHE_HOME, XDG_CONFIG_HOME, \
                       GOENV_CACHE_HOME, GOENV_CONFIG_HOME, \
                       GOLANG_DISTRIBUTIONS_DIR
-from platform import Linux, MacOSX, FreeBSD
+from platform_dependent import Linux, MacOSX, FreeBSD
 from utils import message, default_version, find_for_gopath, ensure_paths, \
                   substitute, ParseGoDL
 

--- a/goenv/platform_dependent.py
+++ b/goenv/platform_dependent.py
@@ -6,6 +6,7 @@ import math
 import os
 import sys
 import tarfile
+import platform
 from clint.textui import progress
 
 from constants import XDG_CACHE_HOME, XDG_CONFIG_HOME, \


### PR DESCRIPTION
Hi!

I renamed platform.py to prevent name collisions with stdlib and fixed it (just add import of original platform module) for correct work on os x.