### PR TITLE
Add basic manifest file for packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include requirements.txt


### PR DESCRIPTION
Source distributions were unusable as they required the `requirements.txt`
file to be present to build which was not being included in the default
source tarball. This change resolves that issue.